### PR TITLE
Refactor: Rename _get_page functions to _get

### DIFF
--- a/pesuacademy/client.py
+++ b/pesuacademy/client.py
@@ -76,10 +76,10 @@ class _PesuScraper:
         self._semester_ids = await _SemesterHandler._get_semester_ids(self._session)
 
     async def get_seating_info(self) -> list[SeatingInformation]:
-        return await _SeatingInformationHandler._get_page(self._session)
+        return await _SeatingInformationHandler._get(self._session)
 
     async def get_profile(self) -> Profile:
-        return await _ProfilePageHandler._get_page(self._session)
+        return await _ProfilePageHandler._get(self._session)
 
     async def get_courses(self, semester: int | None = None) -> dict[int, list[Course]]:
         # Fetch courses for a specific semester or all semesters if none specified
@@ -88,7 +88,7 @@ class _PesuScraper:
             if semester and semester in self._semester_ids
             else self._semester_ids
         )
-        tasks = [_CoursesPageHandler._get_page(self._session, sem_id) for sem_id in semesters_to_fetch.values()]
+        tasks = [_CoursesPageHandler._get(self._session, sem_id) for sem_id in semesters_to_fetch.values()]
         results = await asyncio.gather(*tasks)
         return dict(zip(semesters_to_fetch.keys(), results))
 
@@ -99,24 +99,24 @@ class _PesuScraper:
             if semester and semester in self._semester_ids
             else self._semester_ids
         )
-        tasks = [_AttendancePageHandler._get_page(self._session, sem_id) for sem_id in semesters_to_fetch.values()]
+        tasks = [_AttendancePageHandler._get(self._session, sem_id) for sem_id in semesters_to_fetch.values()]
         results = await asyncio.gather(*tasks)
         return dict(zip(semesters_to_fetch.keys(), results))
 
     async def get_announcements(self) -> list[Announcement]:
-        return await _AnnouncementPageHandler._get_page(self._session)
+        return await _AnnouncementPageHandler._get(self._session)
 
     async def get_units_for_course(self, course_id: str) -> list[Unit]:
-        return await _CourseDetailPageHandler._get_page(self._session, course_id)
+        return await _CourseDetailPageHandler._get(self._session, course_id)
 
     async def get_topics_for_unit(self, unit_id: str) -> list[Topic]:
-        return await _UnitPageHandler._get_page(self._session, unit_id)
+        return await _UnitPageHandler._get(self._session, unit_id)
 
     async def get_material_links(self, topic: Topic, material_type_id: str) -> list[MaterialLink]:
-        return await _MaterialLinksHandler._get_page(self._session, topic, material_type_id)
+        return await _MaterialLinksHandler._get(self._session, topic, material_type_id)
 
     async def get_results(self, semester_id: str) -> SemesterResult:
-        return await _ResultsPageHandler._get_page(self._session, semester_id)
+        return await _ResultsPageHandler._get(self._session, semester_id)
 
     async def close(self) -> None:
         await self._session.aclose()

--- a/pesuacademy/pages/announcements.py
+++ b/pesuacademy/pages/announcements.py
@@ -14,7 +14,7 @@ from pesuacademy.util import _build_params
 
 class _AnnouncementPageHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient) -> list[Announcement]:
+    async def _get(session: httpx.AsyncClient) -> list[Announcement]:
         """Fetches the main announcements page and scrapes all announcements.
 
         Args:

--- a/pesuacademy/pages/attendance.py
+++ b/pesuacademy/pages/attendance.py
@@ -10,7 +10,7 @@ from pesuacademy.util import _build_params
 
 class _AttendancePageHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, semester_id: str) -> list[Course]:
+    async def _get(session: httpx.AsyncClient, semester_id: str) -> list[Course]:
         """Fetches the attendance for a single given semester ID.
 
         Args:

--- a/pesuacademy/pages/course_detail.py
+++ b/pesuacademy/pages/course_detail.py
@@ -12,7 +12,7 @@ from pesuacademy.util import _build_params
 
 class _CourseDetailPageHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, course_id: str) -> list[Unit]:
+    async def _get(session: httpx.AsyncClient, course_id: str) -> list[Unit]:
         """Fetches the main page for a course and scrapes the list of units.
 
         Args:

--- a/pesuacademy/pages/courses.py
+++ b/pesuacademy/pages/courses.py
@@ -10,7 +10,7 @@ from pesuacademy.util import _build_params
 
 class _CoursesPageHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, semester_id: str) -> list[Course]:
+    async def _get(session: httpx.AsyncClient, semester_id: str) -> list[Course]:
         """Fetches the courses for a single given semester ID.
 
         Args:

--- a/pesuacademy/pages/esa_result.py
+++ b/pesuacademy/pages/esa_result.py
@@ -90,7 +90,7 @@ class _ResultsPageHandler:
         return sgpa_raw, credits_earned, credits_total
 
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, semester_id: str) -> SemesterResult:
+    async def _get(session: httpx.AsyncClient, semester_id: str) -> SemesterResult:
         """Fetches the ESA results for a given semester ID.
 
         Args:

--- a/pesuacademy/pages/material_links.py
+++ b/pesuacademy/pages/material_links.py
@@ -12,7 +12,7 @@ from pesuacademy.util import _build_params
 
 class _MaterialLinksHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, topic: Topic, material_type_id: str) -> list[MaterialLink]:
+    async def _get(session: httpx.AsyncClient, topic: Topic, material_type_id: str) -> list[MaterialLink]:
         """Fetches the material links for a given topic and material type ID.
 
         Args:

--- a/pesuacademy/pages/profile.py
+++ b/pesuacademy/pages/profile.py
@@ -145,7 +145,7 @@ class _ProfilePageHandler:
         )
 
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient) -> Profile:
+    async def _get(session: httpx.AsyncClient) -> Profile:
         """Fetches and parses the user's profile page.
 
         Args:

--- a/pesuacademy/pages/seating_information.py
+++ b/pesuacademy/pages/seating_information.py
@@ -10,7 +10,7 @@ from pesuacademy.util import _build_params
 
 class _SeatingInformationHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient) -> list[SeatingInformation]:
+    async def _get(session: httpx.AsyncClient) -> list[SeatingInformation]:
         """Fetches and parses the seating information page.
 
         Args:

--- a/pesuacademy/pages/unit.py
+++ b/pesuacademy/pages/unit.py
@@ -12,7 +12,7 @@ from pesuacademy.util import _build_params
 
 class _UnitPageHandler:
     @staticmethod
-    async def _get_page(session: httpx.AsyncClient, unit_id: str) -> list[Topic]:
+    async def _get(session: httpx.AsyncClient, unit_id: str) -> list[Topic]:
         """Fetches the page for a specific unit and scrapes the list of topics and their required IDs.
 
         Args:


### PR DESCRIPTION
Hi this is my first contribution :D This pull request resolves issue #28 by renaming all instances of the `_get_page` method to `_get`.

I have successfully run the test to confirm that these changes introduce no regressions.

Closes #28